### PR TITLE
Implement date formatting by composing formatting functions

### DIFF
--- a/src/ISO8601/Formatter.elm
+++ b/src/ISO8601/Formatter.elm
@@ -1,4 +1,18 @@
-module ISO8601.Formatter exposing (toString)
+module ISO8601.Formatter
+    exposing
+        ( toString
+        , fmt
+        , year
+        , month
+        , day
+        , hour
+        , minute
+        , second
+        , millisecond
+        , offset
+        , sym
+        , pad0
+        )
 
 import String exposing (padLeft)
 import ISO8601.Types exposing (Time, Offset)


### PR DESCRIPTION
Implements date formatting by composing formatting functions as briefly discussed in #2. 

Threw this together rather quickly. Will improve docs if we decide to go with this approach.

Anyways, the `toString` function works as usual, now you can however use the formatting functions to easily create your own formatter.

```elm
toYMD : Time -> String
toYMD =
    fmt (pad0 4 year >> sym "-" >> pad0 2 month >> sym "-" >> pad0 2 day)

toDayMonth : Time -> String
toDayMonth =
    fmt (day >> sym "/" >> month)
```

I think the `pad0` function makes it a bit messy. Also still missing functions for 12-hour format, but it'd be trivial to add.